### PR TITLE
Lkh with progress estimation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Do not track object files or executables
+sop_solver
+*.o
+
+*.log
+*.callgrind

--- a/lib/history.hpp
+++ b/lib/history.hpp
@@ -18,16 +18,16 @@ struct HistoryContent {
 
 struct Active_Node {
     HistoryNode* history_link = NULL;
-	int32_t total_children_cnt = 0;
-    int32_t cur_children_cnt = 0;
+	int32_t total_children_cnt = 0; //total number of children of this node
+    int32_t cur_children_cnt = 0;	//number of children processed so far
     atomic<int16_t> cur_threadID;
 	atomic<bool> deprecated;
 	mutex nlck;
 };
 
 struct HistoryNode {
-	atomic<bool> explored;
-	atomic<uint8_t> active_threadID;
+	atomic<bool> explored; //if the subspace under this node has already been fully explored
+	atomic<uint8_t> active_threadID; //the thread that is exploring that subspace
 	atomic<HistoryContent> Entry;
 };
 

--- a/lib/solver.hpp
+++ b/lib/solver.hpp
@@ -215,7 +215,7 @@ struct sop_state {
     pair<boost::dynamic_bitset<>,int> key;
     HistoryNode* cur_parent_hisnode = NULL;
     int cur_cost = 0;
-    int initial_depth = 0; //number of nodes in the current path
+    int initial_depth = 0; //depth at which enumeration began once GPQ was initially filled
     int suffix_cost = 0;
     ////////////////////
     int originate = -1;
@@ -287,7 +287,7 @@ class solver {
 
         /* Called from solver::solve, divides work among global pool and each thread, and begins the threads with calls to solver::enumerate. */
         void solve_parallel(int thread_num, int pool_size); 
-        /* Returns true if any solver has a depth different than target_level, false otherwise. */
+        /* Returns true if any solver has a depth different than any other, false otherwise. */
         bool Split_level_check(deque<sop_state>* solver_container);
 
         /* Recursive function that each thread runs to process its assigned sections of the enumeration tree. */
@@ -308,7 +308,8 @@ class solver {
         /* Build a hungarian solver state based upon the problem_state. Used in Generate_SolverState. */
         void regenerate_hungstate();
 
-        /* Moves a node into a global or local pool. Returns true if the node was added, false if the node was pruned. */
+        /* Moves a node into a global or local pool. Returns true if the node was added, false if the node was pruned. 
+            Progress tracking for pruned nodes is done internally. */
         bool assign_workload(node& transfer_wlkload, pool_dest destination, space_ranking problem_property, HistoryNode* temp_hisnode);
         /* Push all nodes from this thread's local pool into a global pool. */
         bool push_to_pool(pool_dest decision, space_ranking problem_property);
@@ -339,7 +340,7 @@ class solver {
             bool Steal_Workload();
             /* Idle thread randomly chooses a victim thread and takes some nodes from its local_pool to the wrksteal_pool. */
             void transfer_wlkload();
-            void check_workload_request(int i);
+            //void check_workload_request(int i);
 
         //Thread Stopping
             /* For Thread Stopping. Check the request buffer. */

--- a/run_soplib_lkh.sh
+++ b/run_soplib_lkh.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# delete the files to output values to
+start=1				# set to 1 in order to start from the beginning
+starting_instance="R.300.1000.15.sop"
+num_threads=32 		# check 8, 16, 32
+enable=1			# 1 for enabling LKH thread, 0 for disabled
+if [[ $enable == 1 ]]; then
+	config="soplib_config.txt"
+else
+	config="soplib_config_disable.txt"
+fi
+
+if [[ $start == 1 ]]; then
+	rm -f outfile.log
+	rm -f outfile_raw.log
+	rm -f outfile_joined.log
+	if [[ $enable == 1 ]]; then
+		echo "lkh + B&B" >> outfile.log
+		echo "lkh + B&B" >> outfile_raw.log
+	else
+		echo "B&B alone" >> outfile.log
+		echo "B&B alone" >> outfile_raw.log
+	fi
+	echo $num_threads threads >> outfile.log
+	echo $num_threads threads >> outfile_raw.log
+fi
+
+# run the tests
+for str in $(ls soplib);
+do
+	if [[ $start == 1 ]]; then
+		if [[ ${str: -6:2} != "BB" ]]; then #ignore the old B&B files that don't have necessary header data
+			if [[ !($str != "R.400.1000.1.sop" && $str != "R.600.1000.1.sop" && $str != "R.600.1000.15.sop" && $str != "R.700.1000.1.sop" && $str != "R.700.1000.15.sop") ]]; then
+				echo $str >> outfile.log
+				output=$(./sop_solver soplib/$str $num_threads $config)
+				echo "$str" >> outfile_raw.log
+				echo "$output" >> outfile_raw.log
+				exit_status=$?
+				if [[ $( echo "$output" | egrep -o "instance timed out" ) != "" ]]; then # test times out
+					echo TIMED OUT >> outfile.log
+				elif [[ $( echo $output | egrep -o "[[:digit:]]+,[[:digit:]]+(.[[:digit:]]+)?" ) != "" ]]; then # test produces usable timing data
+					echo $output | egrep -o "[[:digit:]]+,[[:digit:]]+(.[[:digit:]]+)?" >> outfile.log 
+				fi
+
+				if [[ $( echo $output | egrep -o "Total Progress = 100%" ) == "" ]]; then # if test doesn't end in 100% progress
+					echo PROGRESS BAR NOT 100% >> outfile.log
+					echo PROGRESS BAR NOT 100% >> outfile_raw.log
+				fi
+			fi
+		fi
+	elif [[ $str == $starting_instance ]]; then
+		echo "Starting..."
+		start=1
+	fi 
+done
+
+# join pairs of lines for processing by gnuplot
+# cat outfile.log | paste -d " " - - >> outfile_joined.log

--- a/run_soplib_lkh.sh
+++ b/run_soplib_lkh.sh
@@ -33,9 +33,9 @@ do
 	if [[ $start == 1 ]]; then
 		if [[ ${str: -6:2} != "BB" ]]; then #ignore the old B&B files that don't have necessary header data
 			if [[ 	$dataset == 0 ||
-					($dataset > 0 && ($str != "R.400.1000.1.sop" && $str != "R.600.1000.1.sop" && $str != "R.600.1000.15.sop" && $str != "R.700.1000.1.sop" 
+					($dataset -gt 0 && ($str != "R.400.1000.1.sop" && $str != "R.600.1000.1.sop" && $str != "R.600.1000.15.sop" && $str != "R.700.1000.1.sop" 
 						&& $str != "R.700.1000.15.sop")) ||
-					($dataset < 0 && !($str != "R.400.1000.1.sop" && $str != "R.600.1000.1.sop" && $str != "R.600.1000.15.sop" && $str != "R.700.1000.1.sop" 
+					($dataset -lt 0 && !($str != "R.400.1000.1.sop" && $str != "R.600.1000.1.sop" && $str != "R.600.1000.15.sop" && $str != "R.700.1000.1.sop" 
 						&& $str != "R.700.1000.15.sop"))
 				]]; then
 				echo $str >> outfile.log

--- a/run_tsplib_lkh.sh
+++ b/run_tsplib_lkh.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# delete the files to output values to
+start=1 					# set to 1 in order to start from the beginning
+startInstance="rbg358a.sop"	# instance before the start
+endInstance=""				# instance after the end
+num_threads=32 				# check 8, 16, 32
+enable=1					# 1 for enabling LKH thread, 0 for disabled
+if [[ $enable == 1 ]]; then
+	config="tsplib_config.txt"
+else
+	config="tsplib_config_disable.txt"
+fi
+
+if [[ $start == 1 ]]; then
+	rm -f outfile_tsp.log
+	rm -f outfile_tsp_raw.log
+	rm -f outfile_joined_tsp.log
+	if [[ $enable == 1 ]]; then
+		echo "lkh + B&B" >> outfile_tsp.log
+		echo "lkh + B&B" >> outfile_tsp_raw.log
+	else
+		echo "B&B alone" >> outfile_tsp.log
+		echo "B&B alone" >> outfile_tsp_raw.log
+	fi
+	echo $num_threads threads >> outfile_tsp.log
+	echo $num_threads threads >> outfile_tsp_raw.log
+fi
+
+# run the tests
+for str in $(ls tsplib);
+do
+	if [[ $start == 1 ]]; then
+		if [[ ${str: -6:2} != "BB" ]]; then #ignore the old B&B files that don't have necessary header data
+			if [[ $str != "ESC07_last.sop" && $str != "ESC11_last.sop" ]]; then #these are not "real" instances, ask Taspon about them
+				if [[ !($str != "ESC14.sop" && $str != "ESC98.sop" && $str != "prob.1.sop" && $str != "prob.2.sop" && $str != "prob.3.sop" && $str != "prob.4.sop" && $str != "prob.5.sop" 
+					&& $str != "prob.6.sop" && $str != "prob.7.0.sop" && $str != "prob.7.30.sop" && $str != "prob.7.35.sop" && $str != "prob.7.40.sop" && $str != "prob.7.45.sop" 
+					&& $str != "prob.7.50.sop" && $str != "prob.7.55.sop" && $str != "prob.7.60.sop" && $str != "prob.7.65.sop" && $str != "prob.7.70.sop" 
+					&& $str != "rbg019a.sop" && $str != "rbg019b.sop" && $str != "rbg021a.sop" && $str != "rbg023a.sop" && $str != "rbg029a.sop" && $str != "rbg049a.sop" 
+					&& $str != "rbg050a.sop" && $str != "rbg050b.sop" && $str != "rbg068a.sop" && $str != "rbg088a.sop" && $str != "rbg092a.sop" && $str != "rbg094a.sop"
+					&& $str != "rbg105a.sop" && $str != "rbg113a.sop" && $str != "rbg117a.sop" && $str != "rbg118a.sop" && $str != "rbg124a.sop" && $str != "rbg126a.sop" 
+					&& $str != "rbg143a.sop" && $str != "rbg148a.sop" && $str != "rbg161a.sop" && $str != "rbg190a.sop" && $str != "rbg219a.sop" && $str != "rbg247a.sop"
+					&& $str != "rbg285a.sop") ]]; then # skip instances that only have LKH-structured data files
+					if [[ $str == $endInstance ]]; then
+						exit 1
+					fi
+					if [[ !($str != "ESC78.sop" && $str != "ft53.1.sop" && $str != "ft53.2.sop" && $str != "ft53.3.sop" && $str != "ft70.1.sop" && $str != "ft70.2.sop" && $str != "ft70.3.sop" 
+						&& $str != "kro124p.1.sop" && $str != "kro124p.2.sop" && $str != "kro124p.3.sop" && $str != "kro124p.4.sop" && $str != "p43.1.sop" && $str != "p43.2.sop" 
+						&& $str != "prob.100.sop" && $str != "rbg323a.sop" && $str != "rbg341a.sop" && $str != "rbg358a.sop" && $str != "rbg378a.sop" 
+						&& $str != "ry48p.1.sop" && $str != "ry48p.2.sop" && $str != "ry48p.3.sop") ]]; then # dont skip the instances that always timeout on 32 threads
+						echo $str >> outfile_tsp.log
+						output=$(./sop_solver tsplib/$str $num_threads $config)
+						echo "$str" >> outfile_tsp_raw.log
+						echo "$output" >> outfile_tsp_raw.log
+						exit_status=$?
+						if [[ $( echo "$output" | egrep -o "instance timed out" ) != "" ]]; then # test times out
+							echo TIMED OUT >> outfile_tsp.log
+						elif [[ $( echo $output | egrep -o "[[:digit:]]+,[[:digit:]]+(.[[:digit:]]+)?" ) != "" ]]; then # test produces usable timing data
+							echo $output | egrep -o "[[:digit:]]+,[[:digit:]]+(.[[:digit:]]+)?" >> outfile_tsp.log 
+						fi
+
+						if [[ $( echo $output | egrep -o "Total Progress = 100%" ) == "" ]]; then # if test doesn't end in 100% progress
+							echo PROGRESS BAR NOT 100% >> outfile.log
+							echo PROGRESS BAR NOT 100% >> outfile_raw.log
+						fi
+					fi
+				fi
+			fi
+		fi
+	elif [[ $str == $startInstance ]]; then
+		echo "Starting..."
+		start=1
+	fi 
+done
+
+# join pairs of lines for processing by gnuplot
+# cat outfile_tsp.log | paste -d " " - - >> outfile_joined_tsp.log

--- a/run_tsplib_lkh.sh
+++ b/run_tsplib_lkh.sh
@@ -2,9 +2,9 @@
 
 # delete the files to output values to
 start=0 					# set to 1 in order to start from the beginning
-startInstance="ESC78.sop"	# instance before the start
+startInstance="ft70.1.sop"	# instance before the start
 endInstance=""				# instance after the end
-dataset=0					# which instances to consider: 1 to exclude very hard instances, 0 for all instances, -1 for only very hard instances
+dataset=-1					# which instances to consider: 1 to exclude very hard instances, 0 for all instances, -1 for only very hard instances
 num_threads=32 				# check 8, 16, 32
 enable=1					# 1 for enabling LKH thread, 0 for disabled
 if [[ $enable == 1 ]]; then
@@ -48,11 +48,11 @@ do
 					&& $str != "rbg143a.sop" && $str != "rbg148a.sop" && $str != "rbg161a.sop" && $str != "rbg190a.sop" && $str != "rbg219a.sop" && $str != "rbg247a.sop"
 					&& $str != "rbg285a.sop") ]]; then # skip instances that only have LKH-structured data files
 					if [[ 	$dataset == 0 ||
-							($dataset > 0 && ($str != "ESC78.sop" && $str != "ft53.1.sop" && $str != "ft53.2.sop" && $str != "ft53.3.sop" && $str != "ft70.1.sop" && $str != "ft70.2.sop" 
+							($dataset -gt "0" && ($str != "ESC78.sop" && $str != "ft53.1.sop" && $str != "ft53.2.sop" && $str != "ft53.3.sop" && $str != "ft70.1.sop" && $str != "ft70.2.sop" 
 								&& $str != "ft70.3.sop" && $str != "kro124p.1.sop" && $str != "kro124p.2.sop" && $str != "kro124p.3.sop" && $str != "kro124p.4.sop" && $str != "p43.1.sop" 
 								&& $str != "p43.2.sop" && $str != "prob.100.sop" && $str != "rbg323a.sop" && $str != "rbg341a.sop" && $str != "rbg358a.sop" && $str != "rbg378a.sop" 
 								&& $str != "ry48p.1.sop" && $str != "ry48p.2.sop" && $str != "ry48p.3.sop")) ||
-							($dataset < 0 && !($str != "ESC78.sop" && $str != "ft53.1.sop" && $str != "ft53.2.sop" && $str != "ft53.3.sop" && $str != "ft70.1.sop" && $str != "ft70.2.sop" 
+							($dataset -lt "0" && !($str != "ESC78.sop" && $str != "ft53.1.sop" && $str != "ft53.2.sop" && $str != "ft53.3.sop" && $str != "ft70.1.sop" && $str != "ft70.2.sop" 
 								&& $str != "ft70.3.sop" && $str != "kro124p.1.sop" && $str != "kro124p.2.sop" && $str != "kro124p.3.sop" && $str != "kro124p.4.sop" && $str != "p43.1.sop" 
 								&& $str != "p43.2.sop" && $str != "prob.100.sop" && $str != "rbg323a.sop" && $str != "rbg341a.sop" && $str != "rbg358a.sop" && $str != "rbg378a.sop" 
 								&& $str != "ry48p.1.sop" && $str != "ry48p.2.sop" && $str != "ry48p.3.sop"))

--- a/run_tsplib_lkh.sh
+++ b/run_tsplib_lkh.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 # delete the files to output values to
-start=1 					# set to 1 in order to start from the beginning
-startInstance="rbg358a.sop"	# instance before the start
+start=0 					# set to 1 in order to start from the beginning
+startInstance="ESC78.sop"	# instance before the start
 endInstance=""				# instance after the end
+dataset=0					# which instances to consider: 1 to exclude very hard instances, 0 for all instances, -1 for only very hard instances
 num_threads=32 				# check 8, 16, 32
 enable=1					# 1 for enabling LKH thread, 0 for disabled
 if [[ $enable == 1 ]]; then
@@ -31,9 +32,14 @@ fi
 for str in $(ls tsplib);
 do
 	if [[ $start == 1 ]]; then
+		if [[ $str == $endInstance ]]; then
+			echo "...script ended early"
+			exit 1
+		fi 
+
 		if [[ ${str: -6:2} != "BB" ]]; then #ignore the old B&B files that don't have necessary header data
 			if [[ $str != "ESC07_last.sop" && $str != "ESC11_last.sop" ]]; then #these are not "real" instances, ask Taspon about them
-				if [[ !($str != "ESC14.sop" && $str != "ESC98.sop" && $str != "prob.1.sop" && $str != "prob.2.sop" && $str != "prob.3.sop" && $str != "prob.4.sop" && $str != "prob.5.sop" 
+				if [[ ($str != "ESC14.sop" && $str != "ESC98.sop" && $str != "prob.1.sop" && $str != "prob.2.sop" && $str != "prob.3.sop" && $str != "prob.4.sop" && $str != "prob.5.sop" 
 					&& $str != "prob.6.sop" && $str != "prob.7.0.sop" && $str != "prob.7.30.sop" && $str != "prob.7.35.sop" && $str != "prob.7.40.sop" && $str != "prob.7.45.sop" 
 					&& $str != "prob.7.50.sop" && $str != "prob.7.55.sop" && $str != "prob.7.60.sop" && $str != "prob.7.65.sop" && $str != "prob.7.70.sop" 
 					&& $str != "rbg019a.sop" && $str != "rbg019b.sop" && $str != "rbg021a.sop" && $str != "rbg023a.sop" && $str != "rbg029a.sop" && $str != "rbg049a.sop" 
@@ -41,27 +47,32 @@ do
 					&& $str != "rbg105a.sop" && $str != "rbg113a.sop" && $str != "rbg117a.sop" && $str != "rbg118a.sop" && $str != "rbg124a.sop" && $str != "rbg126a.sop" 
 					&& $str != "rbg143a.sop" && $str != "rbg148a.sop" && $str != "rbg161a.sop" && $str != "rbg190a.sop" && $str != "rbg219a.sop" && $str != "rbg247a.sop"
 					&& $str != "rbg285a.sop") ]]; then # skip instances that only have LKH-structured data files
-					if [[ $str == $endInstance ]]; then
-						exit 1
-					fi
-					if [[ !($str != "ESC78.sop" && $str != "ft53.1.sop" && $str != "ft53.2.sop" && $str != "ft53.3.sop" && $str != "ft70.1.sop" && $str != "ft70.2.sop" && $str != "ft70.3.sop" 
-						&& $str != "kro124p.1.sop" && $str != "kro124p.2.sop" && $str != "kro124p.3.sop" && $str != "kro124p.4.sop" && $str != "p43.1.sop" && $str != "p43.2.sop" 
-						&& $str != "prob.100.sop" && $str != "rbg323a.sop" && $str != "rbg341a.sop" && $str != "rbg358a.sop" && $str != "rbg378a.sop" 
-						&& $str != "ry48p.1.sop" && $str != "ry48p.2.sop" && $str != "ry48p.3.sop") ]]; then # dont skip the instances that always timeout on 32 threads
+					if [[ 	$dataset == 0 ||
+							($dataset > 0 && ($str != "ESC78.sop" && $str != "ft53.1.sop" && $str != "ft53.2.sop" && $str != "ft53.3.sop" && $str != "ft70.1.sop" && $str != "ft70.2.sop" 
+								&& $str != "ft70.3.sop" && $str != "kro124p.1.sop" && $str != "kro124p.2.sop" && $str != "kro124p.3.sop" && $str != "kro124p.4.sop" && $str != "p43.1.sop" 
+								&& $str != "p43.2.sop" && $str != "prob.100.sop" && $str != "rbg323a.sop" && $str != "rbg341a.sop" && $str != "rbg358a.sop" && $str != "rbg378a.sop" 
+								&& $str != "ry48p.1.sop" && $str != "ry48p.2.sop" && $str != "ry48p.3.sop")) ||
+							($dataset < 0 && !($str != "ESC78.sop" && $str != "ft53.1.sop" && $str != "ft53.2.sop" && $str != "ft53.3.sop" && $str != "ft70.1.sop" && $str != "ft70.2.sop" 
+								&& $str != "ft70.3.sop" && $str != "kro124p.1.sop" && $str != "kro124p.2.sop" && $str != "kro124p.3.sop" && $str != "kro124p.4.sop" && $str != "p43.1.sop" 
+								&& $str != "p43.2.sop" && $str != "prob.100.sop" && $str != "rbg323a.sop" && $str != "rbg341a.sop" && $str != "rbg358a.sop" && $str != "rbg378a.sop" 
+								&& $str != "ry48p.1.sop" && $str != "ry48p.2.sop" && $str != "ry48p.3.sop"))
+						]]; then # dont skip the instances that always timeout on 32 threads
 						echo $str >> outfile_tsp.log
 						output=$(./sop_solver tsplib/$str $num_threads $config)
 						echo "$str" >> outfile_tsp_raw.log
 						echo "$output" >> outfile_tsp_raw.log
-						exit_status=$?
+						
 						if [[ $( echo "$output" | egrep -o "instance timed out" ) != "" ]]; then # test times out
 							echo TIMED OUT >> outfile_tsp.log
-						elif [[ $( echo $output | egrep -o "[[:digit:]]+,[[:digit:]]+(.[[:digit:]]+)?" ) != "" ]]; then # test produces usable timing data
-							echo $output | egrep -o "[[:digit:]]+,[[:digit:]]+(.[[:digit:]]+)?" >> outfile_tsp.log 
+						elif [[ $( echo $output | egrep -o "[[:digit:]]+,[[:digit:]]+(.[[:digit:]]+)?" ) == "" ]]; then # time and cost not printed at the end
+							echo NO TIMING DATA >> outfile_tsp.log
+						else # output timing data to file
+							echo $output | egrep -o "[[:digit:]]+,[[:digit:]]+(.[[:digit:]]+)?" >> outfile_tsp.log # add " | cut -d, -f2" to find only the time
 						fi
 
 						if [[ $( echo $output | egrep -o "Total Progress = 100%" ) == "" ]]; then # if test doesn't end in 100% progress
-							echo PROGRESS BAR NOT 100% >> outfile.log
-							echo PROGRESS BAR NOT 100% >> outfile_raw.log
+							echo PROGRESS BAR NOT 100% >> outfile_tsp.log
+							echo PROGRESS BAR NOT 100% >> outfile_tsp_raw.log
 						fi
 					fi
 				fi

--- a/soplib_config.txt
+++ b/soplib_config.txt
@@ -27,3 +27,6 @@ Enable = 1
 
 //Run in parallel with LKH (1 for enable 0 for disable)
 Enable = 1
+
+//Enable Progress Estimation (1 for enable 0 for disable)
+Enable = 1

--- a/tsplib_config.txt
+++ b/tsplib_config.txt
@@ -27,3 +27,6 @@ Enable = 1
 
 //Run in parallel with LKH (1 for enable 0 for disable)
 Enable = 1
+
+//Enable Progress Estimation (1 for enable 0 for disable)
+Enable = 1


### PR DESCRIPTION
Added progress tracking to the parallel solver with lkh. Tracked separately in each thread. 

Because of imprecision, the total progress on a completed instance is not expected to reach exactly ULLONG_MAX, but the difference is expected to be much less than 10^-5.

There is still some problem, either in some part of work stealing or thread restart, that leads to instances sometimes reporting only 99% progress even when finished, but this appears to be rare and probably not very important for our intended purpose.